### PR TITLE
Make hold timer decimals configurable

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -24,6 +24,7 @@ hold_timer_font_spacing = 0
 hold_timer_font_size = 14
 hold_timer_font_padding = 5
 hold_timer_y_offset = 0
+hold_timer_decimals = 6 # minimum value is 3
 trail_speed = 700
 trail_width = 60
 trail_offset = -1 # 1 = starts at top, 0 = starts in the middle, -1 = starts at the bottom

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -30,6 +30,7 @@ struct general_config final {
     int hold_timer_font_size = 14;
     int hold_timer_font_padding = 5;
     int hold_timer_y_offset = 0;
+    int hold_timer_decimals = 6;
 
     int trail_speed = 700;
     int trail_width = 60;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "config.hpp"
 #include "createitem.hpp"
 #include <toml.hpp>
+#include <sstream>
 
 Color hexStringToInt(std::string hexString) {
     hexString = hexString.substr(1); // get rid of the # at the start (reading from toml config)
@@ -51,6 +52,8 @@ int main() {
     int holdTimerFontSize = config["general"]["hold_timer_font_size"].value_or(14);
     int holdTimerFontPadding = config["general"]["hold_timer_font_padding"].value_or(5);
     int holdTimerYOffset = config["general"]["hold_timer_y_offset"].value_or(5);
+    int holdTimerDecimals = config["general"]["hold_timer_decimals"].value_or(6);
+    if (holdTimerDecimals < 3) holdTimerDecimals = 3; // minimum value so users can't effectively disable this feature
 
     int trailSpeed = config["general"]["trail_speed"].value_or(700);
     int trailWidth = config["general"]["trail_width"].value_or(60);
@@ -194,7 +197,10 @@ int main() {
             // Held Timer Text Logic
 
             float holdTimer = button_states[i].hold_timer;
-            std::string holdTimerString = std::to_string(holdTimer);
+            //std::string holdTimerString = std::to_string(holdTimer);
+            std::stringstream holdTimerStream;
+            holdTimerStream << std::fixed << std::setprecision(holdTimerDecimals) << holdTimer;
+            std::string holdTimerString = holdTimerStream.str();
 
             int padding = holdTimerFontPadding;
             int maxTimerWidth = fretVector[i].x - padding * 2;


### PR DESCRIPTION
Hardcoded a minimum of 3 decimals so the hold timer can't be effectively disabled. Default is still 6